### PR TITLE
Minor changes on _data/links.yml

### DIFF
--- a/_data/links.yml
+++ b/_data/links.yml
@@ -386,7 +386,7 @@
 
     - name: VPN服务
       style: basic
-      url: http://nic.bupt.edu.cn/list/list.php?p=3_24_1
+      url: https://nic.bupt.edu.cn/list/list.php?p=5_13_1
 
     - name: 空闲自习室查询
       style: basic

--- a/_data/links.yml
+++ b/_data/links.yml
@@ -334,15 +334,15 @@
     links:
     - name: 北邮官网
       style: basic
-      url: http://www.bupt.edu.cn/
+      url: https://www.bupt.edu.cn/
 
-    - name: 官方导航
-      style: basic
-      url: http://dep.bupt.edu.cn/dh/
+    # - name: 官方导航
+    #   style: basic
+    #   url: http://dep.bupt.edu.cn/dh/
 
     - name: 本科教务系统
       style: basic
-      url: http://jwxt.bupt.edu.cn/
+      url: https://jwgl.bupt.edu.cn/jsxsd/
 
     - name: 研究生教务系统
       style: basic
@@ -479,12 +479,12 @@
     - name: 论坛APP
       icon: app store
       style: black
-      url: http://itunes.apple.com/cn/app/bei-you-ren-lun-tan-bei-you/id1115232927
+      url: https://apps.apple.com/cn/app/id1115232927
 
     - name: 论坛APP
       icon: google play
       style: black
-      url: https://github.com/dss886/BYR-BBS-APP-Release
+      url: https://github.com/BYR-App-Dev/BYR_App_Android_Release/releases
 
     - name: 论坛官方微博
       style: basic


### PR DESCRIPTION
- Bump BUPT Portal link from http to https.
- Comment out "Official Navigator"(dep.bupt.edu.cn), which is currently not available.
- Change JWXT for undergraduate studnets URL, refering
  https://bbs.byr.cn/#!article/jiaowu_newSystem/2, in which saying, "新版本科教务系统网址如下：教师、学生请登录：http://jwgl.bupt.edu.cn/jsxsd".
- Update BYRBBS official mobile apps release page link, refering
  https://bbs.byr.cn/#!article/Announce/261.
- Update NIC VPN service URL to https://nic.bupt.edu.cn/list/list.php?p=5_13_1